### PR TITLE
Fixed empty Bintray credentials preventing opening the project.

### DIFF
--- a/alerter/build.gradle
+++ b/alerter/build.gradle
@@ -36,8 +36,8 @@ android {
 
 //BinTray configuration - credentials stored in user's gradle.properties
 bintray {
-    user = BINTRAY_USER
-    key  = BINTRAY_KEY
+    user = hasProperty('BINTRAY_USER')? getProperty('BINTRAY_USER') : null
+    key  = hasProperty('BINTRAY_KEY')? getProperty('BINTRAY_KEY') : null
 
     publications = ['Alerter']
 


### PR DESCRIPTION
Detailed info about the issue: #4

This PR will allow anyone to open the project in their Android Studio, unlike previously. The Bintray credentials are still fetched from the gradle properties, but if they don't exist, the project will still open.