### PR TITLE
Remove supportsRtl attribute

### DIFF
--- a/alerter/src/main/AndroidManifest.xml
+++ b/alerter/src/main/AndroidManifest.xml
@@ -6,8 +6,7 @@
     <!-- Our Min SDK is 16, UI Automator requires Min 18, so this will force its use -->
     <uses-sdk tools:overrideLibrary="android.support.test.uiautomator.v18"/>
 
-    <application
-        android:supportsRtl="true">
+    <application>
 
         <!--This is just an Activity for Testing from within src/androidTest-->
         <activity


### PR DESCRIPTION
The library should support RTL layouts but let the app using it decide whether to support it or not. This will prevent the use of tools:replace="android:supportsRtl" on apps that do not support it.