### PR TITLE
Add method to hide alert for Alerter.

### DIFF
--- a/alerter/src/main/java/com/tapadoo/alerter/Alerter.java
+++ b/alerter/src/main/java/com/tapadoo/alerter/Alerter.java
@@ -112,6 +112,15 @@ public final class Alerter {
     }
 
     /**
+     * Hides currently showing alert.
+     */
+    public void hide() {
+        if (getAlert() != null) {
+            getAlert().hide();
+        }
+    }
+
+    /**
      * Sets the title of the Alert
      *
      * @param titleId Title String Resource


### PR DESCRIPTION
Sometimes it's useful to have an ability to hide current alert, for example when you set a click listener and it changes default behaviour (hiding alert). I know about workaround when you can save an instance of alert itself from the show() method, but have a direct method looks more convenient for me.

#34 