### PR TITLE
Fixed force close for 4.4 devices

### DIFF
--- a/alerter/src/main/java/com/tapadoo/alerter/Alert.java
+++ b/alerter/src/main/java/com/tapadoo/alerter/Alert.java
@@ -9,7 +9,7 @@ import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
-import android.support.v4.content.ContextCompat;
+import android.support.graphics.drawable.VectorDrawableCompat;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.Log;
@@ -317,6 +317,10 @@ public class Alert extends FrameLayout implements View.OnClickListener, Animatio
         setText(getContext().getString(textId));
     }
 
+    public int getContentGravity() {
+        return ((LayoutParams) rlContainer.getLayoutParams()).gravity;
+    }
+
     /**
      * Sets the Gravity of the Alert
      *
@@ -325,10 +329,6 @@ public class Alert extends FrameLayout implements View.OnClickListener, Animatio
     public void setContentGravity(final int contentGravity) {
         ((LayoutParams) rlContainer.getLayoutParams()).gravity = contentGravity;
         rlContainer.requestLayout();
-    }
-
-    public int getContentGravity() {
-        return ((LayoutParams) rlContainer.getLayoutParams()).gravity;
     }
 
     public FrameLayout getAlertBackground() {
@@ -377,7 +377,7 @@ public class Alert extends FrameLayout implements View.OnClickListener, Animatio
      * @param iconId Drawable resource id of the icon to use in the Alert
      */
     public void setIcon(@DrawableRes final int iconId) {
-        final Drawable iconDrawable = ContextCompat.getDrawable(getContext(), iconId);
+        final Drawable iconDrawable = VectorDrawableCompat.create(getContext().getResources(), iconId, null);
         ivIcon.setImageDrawable(iconDrawable);
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.1'
     }
 }
 


### PR DESCRIPTION
Previously the library would crash when I tried to set a custom icon (on Android 4.4 devices) with the following exception

```android.content.res.Resources$NotFoundException: File res/drawable/ic_update.xml from drawable resource ID #0x7f0200d3```

After this fix it should work as intended

I think Google messed something up with their ContextCompact.getDrawable function

I replaced 

```
public void setIcon(@DrawableRes final int iconId) {
        final Drawable iconDrawable = ContextCompact.getDrawable(getContext(), iconId);
        ivIcon.setImageDrawable(iconDrawable);
    }

```
with
```

public void setIcon(@DrawableRes final int iconId) {
        final Drawable iconDrawable = VectorDrawableCompat.create(getContext().getResources(), iconId, null);
        ivIcon.setImageDrawable(iconDrawable);
    }
```