### PR TITLE
Add `setBackgroundColorInt` to Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ all content.
 
 ```groovy
 dependencies {
-    compile 'com.tapadoo.android:alerter:1.0.8'
+    compile 'com.tapadoo.android:alerter:1.0.9'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Alerter.create(getActivity())
 Alerter.create(this)
        .setTitle("Alert Title")
        .setText("Alert text...")
-       .setBackgroundColor(R.color.colorAccent)
+       .setBackgroundColor(R.color.colorAccent) // or setBackgroundColorInt(Color.CYAN)
        .show();
 ```
 
@@ -152,9 +152,3 @@ See the [LICENSE](LICENSE.md) file for license rights and limitations (MIT).
 Copyright 2016 Tapadoo, Dublin.
 
 ![Alt Text](http://tapadoo.com/wp-content/themes/tapadoo/img/tapadoo-logo@2x.png)
-
-
-
-
-
-

--- a/alerter/build.gradle
+++ b/alerter/build.gradle
@@ -11,7 +11,7 @@ apply plugin: "maven-publish"
 apply from: rootProject.file('quality.gradle')
 
 def final String PACKAGE_NAME = "com.tapadoo.android"
-def final String VERSION      = "1.0.8"
+def final String VERSION      = "1.0.9"
 def final String DESCRIPTION  = "An Android Alerting Library"
 def final String GITHUB_URL   = "https://github.com/Tapadoo/Alerter"
 

--- a/alerter/src/main/java/com/tapadoo/alerter/Alerter.java
+++ b/alerter/src/main/java/com/tapadoo/alerter/Alerter.java
@@ -3,6 +3,7 @@ package com.tapadoo.alerter;
 import android.app.Activity;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
+import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
@@ -203,6 +204,20 @@ public final class Alerter {
     public Alerter setBackgroundColor(@ColorRes final int colorResId) {
         if (getAlert() != null && getActivityWeakReference() != null) {
             getAlert().setAlertBackgroundColor(ContextCompat.getColor(getActivityWeakReference().get(), colorResId));
+        }
+
+        return this;
+    }
+
+    /**
+     * Set the Alert's Background Colour
+     *
+     * @param colorInt Colour Int
+     * @return This Alerter
+     */
+    public Alerter setBackgroundColorInt(@ColorInt final int colorInt) {
+        if (getAlert() != null) {
+            getAlert().setAlertBackgroundColor(colorInt);
         }
 
         return this;


### PR DESCRIPTION
The motivation for this PR is to allow more control over how to use the library (and the `Alerter.Builder`). Technically it is not needed as you can get a reference to the underlying `Alert` once you create it but having it in the builder would be easier to use:
- could use arbitrary colors to be passed onto the Alert (like dynamic colors related to the content);
- could have more control over how to retrieve the color in case of colorId (use a different context for example)

It's a big breaking change, but I think it's a step in the right direction as even Google uses similar APIs for `View`s (see [TextView.setTextColor](https://developer.android.com/reference/android/widget/TextView.html#setTextColor(int))).

Anyway thanks for the library!