### PR TITLE
Removed hard coded colors and added resources that can be overridden

### DIFF
--- a/alerter/src/main/res/layout/alerter_alert_view.xml
+++ b/alerter/src/main/res/layout/alerter_alert_view.xml
@@ -36,7 +36,7 @@
                 android:maxHeight="@dimen/alerter_alert_icn_size"
                 android:maxWidth="@dimen/alerter_alert_icn_size"
                 android:src="@drawable/alerter_ic_notifications"
-                android:tint="@android:color/white"/>
+                android:tint="@color/alert_default_icon_color"/>
 
             <LinearLayout
                 android:id="@+id/llAlertTextContainer"
@@ -59,7 +59,6 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:textAppearance="@style/AlertTextAppearance.Title"
-                    android:textColor="@android:color/white"
                     android:visibility="gone"
                     tools:text="Title"
                     tools:visibility="visible"/>
@@ -71,7 +70,6 @@
                     android:paddingBottom="@dimen/alerter_padding_small"
                     android:paddingTop="@dimen/alerter_padding_small"
                     android:textAppearance="@style/AlertTextAppearance.Text"
-                    android:textColor="@android:color/white"
                     android:visibility="gone"
                     tools:text="Text"
                     tools:visibility="visible"/>

--- a/alerter/src/main/res/values-v16/styles.xml
+++ b/alerter/src/main/res/values-v16/styles.xml
@@ -2,6 +2,6 @@
 <resources>
     <style name="AlertTextAppearance">
         <item name="android:fontFamily">sans-serif</item>
-        <item name="android:textColor">@android:color/white</item>
+        <item name="android:textColor">@color/alert_default_text_color</item>
     </style>
 </resources>

--- a/alerter/src/main/res/values/colors.xml
+++ b/alerter/src/main/res/values/colors.xml
@@ -2,4 +2,6 @@
 <resources>
     <color name="alerter_default_success_background">#4CAF50</color>
     <color name="alert_default_error_background">#F44336</color>
+    <color name="alert_default_text_color">@android:color/white</color>
+    <color name="alert_default_icon_color">@android:color/white</color>
 </resources>

--- a/alerter/src/main/res/values/styles.xml
+++ b/alerter/src/main/res/values/styles.xml
@@ -17,7 +17,7 @@
     </style>
 
     <style name="AlertTextAppearance">
-        <item name="android:textColor">@android:color/white</item>
+        <item name="android:textColor">@color/alert_default_text_color</item>
     </style>
 
     <style name="AlertTextAppearance.Title">


### PR DESCRIPTION
This allows a user to set their own colors in colors.xml to override the icon and text colors from Alerter.  In my project I need my text and icon color to be black and with this all I have to do is add the below colors to my colors.xml.  

```
<color name="alert_default_text_color">@android:color/black</color>
<color name="alert_default_icon_color">@android:color/black</color>
```