### PR TITLE
Add typefaces to button text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 4.0.3 - 1/5/2019
+* Added support for setting custom typefaces for buttons
+
 ## 4.0.2 - 6/3/2019
 * Bug Fixes - Accept CharSequence as parameters instead of String on setTitle, setText, and addButton functions
 

--- a/alerter/build.gradle
+++ b/alerter/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'org.jetbrains.dokka'
 apply from: rootProject.file('quality.gradle')
 
 final String GROUP_ID = "com.tapadoo.android"
-final String VERSION = "4.0.2"
+final String VERSION = "4.0.3"
 final String DESCRIPTION = "An Android Alerting Library"
 final String GITHUB_URL = "https://github.com/Tapadoo/Alerter"
 

--- a/alerter/src/main/java/com/tapadoo/alerter/Alert.kt
+++ b/alerter/src/main/java/com/tapadoo/alerter/Alert.kt
@@ -49,6 +49,7 @@ class Alert @JvmOverloads constructor(context: Context, attrs: AttributeSet? = n
     private var isDismissable = true
 
     private var buttons = ArrayList<Button>()
+    var buttonTypeFace: Typeface? = null
 
     /**
      * Flag to ensure we only set the margins once
@@ -95,8 +96,9 @@ class Alert @JvmOverloads constructor(context: Context, attrs: AttributeSet? = n
         animation = enterAnimation
 
         // Add all buttons
-        buttons.forEach {
-            llButtonContainer.addView(it)
+        buttons.forEach { button ->
+            buttonTypeFace?.let { button.typeface = it }
+            llButtonContainer.addView(button)
         }
     }
 

--- a/alerter/src/main/java/com/tapadoo/alerter/Alerter.kt
+++ b/alerter/src/main/java/com/tapadoo/alerter/Alerter.kt
@@ -511,6 +511,18 @@ class Alerter private constructor() {
     }
 
     /**
+     * Set the Button's Typeface
+     *
+     * @param typeface Typeface to use
+     * @return This Alerter
+     */
+    fun setButtonTypeface(typeface: Typeface): Alerter {
+        alert?.buttonTypeFace = typeface
+
+        return this
+    }
+
+    /**
      * Creates a weak reference to the calling Activity
      *
      * @param activity The calling Activity


### PR DESCRIPTION
This allows a user to set the Typeface to the text of the button with the same syntax as for the title and text of the notification.
Setting custom fonts is not possible via styles (at least not prior to API level 26).

`./gradlew :alerter:assemble check` has no complaints about the changed code.

I targeted `master` not `develop` as it seems to be further along and the current target of development. I can change that if preferred.

Feedback highly appreciated.