### PR TITLE
S10 overshoot fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 6.1.1 - 03/06/2020
+* Updated negative margin to fix overshoot on Samsung S10
+
 ## 6.1.0 - 27/06/2020
 * Readded getters for title & text TextView
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## 6.2.1 - 03/06/2020
+## 6.2.1 - 03/09/2020
 * Updated negative margin to fix overshoot on Samsung S10
 
 ## 6.2.0 - 03/09/2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 6.2.1 - 03/06/2020
+* Updated negative margin to fix overshoot on Samsung S10
+
 ## 6.2.0 - 03/09/2020
 * Added the ability to enable\disable click animation
 

--- a/README.md
+++ b/README.md
@@ -246,4 +246,4 @@ See the [LICENSE](LICENSE.md) file for license rights and limitations (MIT).
 
 Copyright 2017 Tapadoo, Dublin.
 
-![Alt Text](https://tapadoo.com/wp-content/themes/tapadoo/assets/images/tapadoo_logo_dark.png)
+![Alt Text](https://2upm2b1wdft320vzjj34rpga-wpengine.netdna-ssl.com/wp-content/uploads/2019/12/logo-tapadoo-dark.png)

--- a/alerter/build.gradle
+++ b/alerter/build.gradle
@@ -14,7 +14,7 @@ apply from: rootProject.file('quality.gradle')
 
 final String GROUP_ID = "com.tapadoo.android"
 
-final String VERSION = "6.1.0"
+final String VERSION = "6.1.1"
 
 final String DESCRIPTION = "An Android Alerting Library"
 final String GITHUB_URL = "https://github.com/Tapadoo/Alerter"

--- a/alerter/build.gradle
+++ b/alerter/build.gradle
@@ -14,7 +14,7 @@ apply from: rootProject.file('quality.gradle')
 
 final String GROUP_ID = "com.tapadoo.android"
 
-final String VERSION = "6.2.0"
+final String VERSION = "6.2.1"
 
 final String DESCRIPTION = "An Android Alerting Library"
 final String GITHUB_URL = "https://github.com/Tapadoo/Alerter"

--- a/alerter/src/main/res/values/dimens.xml
+++ b/alerter/src/main/res/values/dimens.xml
@@ -8,7 +8,7 @@
     <dimen name="alerter_padding_half">8dp</dimen>
     <dimen name="alerter_padding_default">16dp</dimen>
     <dimen name="alerter_alert_padding">30dp</dimen>
-    <dimen name="alerter_alert_negative_margin_top">-28dp</dimen>
+    <dimen name="alerter_alert_negative_margin_top">-32dp</dimen>
 
     <dimen name="alerter_progress_bar_size">2dp</dimen>
 


### PR DESCRIPTION
@kpmmmurphy finally got a chance to use this library :D

Noticed some overshooting on my S10 though, quickest way I thought to fix was increase the negative margins. This works but moves the alert up slightly in its resting position versus the original margins. 

To my eye it's ok but if you think it will cause issues let me know if there's a better way, been a while since I did Android.

![20200903_134715](https://user-images.githubusercontent.com/11424393/92118586-92da4980-edee-11ea-9a28-e048e2406b7c.jpg)
![20200903_134852](https://user-images.githubusercontent.com/11424393/92118595-966dd080-edee-11ea-95e7-7ec5c555f9c2.jpg)