### PR TITLE
Add onHideListener to hide() & clearCurrent() methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 7.2.0 - 14/05/2021
+* OnHideAlertListener added to hide() and clearCurrent() methods.
+
 ## 7.0.1 - 05/02/2021
 * updated navigation_bar height getter.
 

--- a/alerter/build.gradle
+++ b/alerter/build.gradle
@@ -9,7 +9,7 @@ apply from: rootProject.file('quality.gradle')
 
 final String GROUP_ID = "com.tapadoo.android"
 
-final String VERSION = "7.1.0"
+final String VERSION = "7.2.0"
 
 final String DESCRIPTION = "An Android Alerting Library"
 final String GITHUB_URL = "https://github.com/Tapadoo/Alerter"

--- a/alerter/src/main/java/com/tapadoo/alerter/Alerter.kt
+++ b/alerter/src/main/java/com/tapadoo/alerter/Alerter.kt
@@ -785,6 +785,19 @@ class Alerter private constructor() {
         }
 
         /**
+         * Cleans up the currently showing alert view, if one is present. Either pass
+         * the calling Activity, or the calling Dialog
+         *
+         * @param activity The current Activity
+         * @param listener OnHideAlertListener to known when Alert is dismissed
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun clearCurrent(activity: Activity?, listener: OnHideAlertListener? = null) {
+            clearCurrent(activity, null, listener)
+        }
+
+        /**
          * Hides the currently showing alert view, if one is present
          * @param listener to known when Alert is dismissed
          */

--- a/alerter/src/main/java/com/tapadoo/alerter/Alerter.kt
+++ b/alerter/src/main/java/com/tapadoo/alerter/Alerter.kt
@@ -781,7 +781,7 @@ class Alerter private constructor() {
                 activity?.window?.decorView as? ViewGroup
             }?.also {
                 removeAlertFromParent(it, listener)
-            }
+            } ?: listener?.onHide()
         }
 
         /**
@@ -806,7 +806,7 @@ class Alerter private constructor() {
         fun hide(listener: OnHideAlertListener? = null) {
             decorView?.get()?.let {
                 removeAlertFromParent(it, listener)
-            }
+            } ?: listener?.onHide()
         }
 
         private fun removeAlertFromParent(decorView: ViewGroup, listener: OnHideAlertListener?) {
@@ -839,10 +839,9 @@ class Alerter private constructor() {
         private fun getRemoveViewRunnable(childView: Alert?, listener: OnHideAlertListener?): Runnable {
             return Runnable {
                 childView?.let {
-                    (childView.parent as? ViewGroup)?.removeView(childView).also {
-                        listener?.onHide()
-                    }
+                    (childView.parent as? ViewGroup)?.removeView(childView)
                 }
+                listener?.onHide()
             }
         }
     }

--- a/alerter/src/main/java/com/tapadoo/alerter/Alerter.kt
+++ b/alerter/src/main/java/com/tapadoo/alerter/Alerter.kt
@@ -770,34 +770,38 @@ class Alerter private constructor() {
          *
          * @param activity The current Activity
          * @param dialog The current Dialog
+         * @param listener OnHideAlertListener to known when Alert is dismissed
          */
         @JvmStatic
-        fun clearCurrent(activity: Activity?, dialog: Dialog?) {
+        @JvmOverloads
+        fun clearCurrent(activity: Activity?, dialog: Dialog?, listener: OnHideAlertListener? = null) {
             dialog?.let {
                 it.window?.decorView as? ViewGroup
             } ?: kotlin.run {
                 activity?.window?.decorView as? ViewGroup
             }?.also {
-                removeAlertFromParent(it)
+                removeAlertFromParent(it, listener)
             }
         }
 
         /**
          * Hides the currently showing alert view, if one is present
+         * @param listener to known when Alert is dismissed
          */
         @JvmStatic
-        fun hide() {
+        @JvmOverloads
+        fun hide(listener: OnHideAlertListener? = null) {
             decorView?.get()?.let {
-                removeAlertFromParent(it)
+                removeAlertFromParent(it, listener)
             }
         }
 
-        private fun removeAlertFromParent(decorView: ViewGroup) {
+        private fun removeAlertFromParent(decorView: ViewGroup, listener: OnHideAlertListener?) {
             //Find all Alert Views in Parent layout
             for (i in 0..decorView.childCount) {
                 val childView = if (decorView.getChildAt(i) is Alert) decorView.getChildAt(i) as Alert else null
                 if (childView != null && childView.windowToken != null) {
-                    ViewCompat.animate(childView).alpha(0f).withEndAction(getRemoveViewRunnable(childView))
+                    ViewCompat.animate(childView).alpha(0f).withEndAction(getRemoveViewRunnable(childView, listener))
                 }
             }
         }
@@ -819,10 +823,12 @@ class Alerter private constructor() {
                 return isShowing
             }
 
-        private fun getRemoveViewRunnable(childView: Alert?): Runnable {
+        private fun getRemoveViewRunnable(childView: Alert?, listener: OnHideAlertListener?): Runnable {
             return Runnable {
                 childView?.let {
-                    (childView.parent as? ViewGroup)?.removeView(childView)
+                    (childView.parent as? ViewGroup)?.removeView(childView).also {
+                        listener?.onHide()
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR allows to add the OnHideListener listener in a separate way to the current one when creating an Alerter
```kotlin
//Current code
Alerter.crete(activity)
    .setOnHideListener(listener)
    .show()
```

And this is a new proposal for the different possibilities of closing Alerter outside of its creation.
```kotlin
//Current code
Alerter.crete(activity)
    .show()

---
//New options to hide the Alerter with a listener
Alerter.hide {
   doSomething()
}

Alerter.clearCurrent(activity) {
    doSomething()   
}
```