### PR TITLE
Fixed day night theme issue

### DIFF
--- a/alerter/src/main/java/com/tapadoo/alerter/Alerter.kt
+++ b/alerter/src/main/java/com/tapadoo/alerter/Alerter.kt
@@ -190,7 +190,7 @@ class Alerter private constructor() {
      */
     fun setBackgroundColorRes(@ColorRes colorResId: Int): Alerter {
         decorView?.get()?.let {
-            alert?.setAlertBackgroundColor(ContextCompat.getColor(it.context.applicationContext, colorResId))
+            alert?.setAlertBackgroundColor(ContextCompat.getColor(it.context, colorResId))
         }
 
         return this


### PR DESCRIPTION
When using day night theme, due to application context background color was not picking the right resource
for example when using night mode background resource should use values-night, but was using values
