### PR TITLE
Fix. Extra bottom margin when displayed with Gravity.BOTTOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 7.2.1 - 27/07/2021
+* Fixed alert may has extra bottom margin when displayed with Gravity.BOTTOM
+
 ## 7.2.0 - 14/05/2021
 * OnHideAlertListener added to hide() and clearCurrent() methods.
 
@@ -80,7 +83,7 @@ All notable changes to this project will be documented in this file.
 * Updated build tools & support libs
 * Added methods to set icon tint
 
-## 2.0.2 - 11/12/2017 
+## 2.0.2 - 11/12/2017
 * Added fixed for the Alert drawing under the status bar
 
 ## 2.0.1 - 18/09/2017
@@ -98,7 +101,7 @@ All notable changes to this project will be documented in this file.
 * Added setAlertBackgroundColor to allow the use of color ints
 
 ## 1.0.8 - 09/05/2017
-* Added disable vibration option 
+* Added disable vibration option
 * Updated Alert dismiss method
 * Added method to hide icon
 * Added method to disable outside touch

--- a/alerter/build.gradle
+++ b/alerter/build.gradle
@@ -9,7 +9,7 @@ apply from: rootProject.file('quality.gradle')
 
 final String GROUP_ID = "com.tapadoo.android"
 
-final String VERSION = "7.2.0"
+final String VERSION = "7.2.1"
 
 final String DESCRIPTION = "An Android Alerting Library"
 final String GITHUB_URL = "https://github.com/Tapadoo/Alerter"

--- a/alerter/src/main/java/com/tapadoo/alerter/Alert.kt
+++ b/alerter/src/main/java/com/tapadoo/alerter/Alert.kt
@@ -3,6 +3,7 @@ package com.tapadoo.alerter
 import android.annotation.SuppressLint
 import android.annotation.TargetApi
 import android.content.Context
+import android.content.res.Resources
 import android.graphics.*
 import android.graphics.drawable.Drawable
 import android.media.RingtoneManager
@@ -10,6 +11,7 @@ import android.net.Uri
 import android.os.Build
 import android.text.TextUtils
 import android.util.AttributeSet
+import android.util.DisplayMetrics
 import android.util.Log
 import android.view.*
 import android.view.animation.Animation
@@ -118,9 +120,36 @@ class Alert @JvmOverloads constructor(context: Context,
 
     val layoutContainer: View? by lazy { findViewById<View>(R.id.vAlertContentContainer) }
 
+    private val currentDisplay: Display? by lazy {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            context.display
+        } else {
+            @Suppress("DEPRECATION")
+            (context.applicationContext.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay
+        }
+    }
+
+    private val usableScreenHeight: Int
+        get() = Resources.getSystem().displayMetrics.heightPixels
+
+    private val physicalScreenHeight: Int
+        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            DisplayMetrics().also { currentDisplay?.getRealMetrics(it) }.heightPixels
+        } else {
+            usableScreenHeight
+        }
+
+    private val cutoutsHeight: Int
+        get() = when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q ->
+                currentDisplay?.cutout?.run { safeInsetTop + safeInsetBottom } ?: 0
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.P ->
+                rootWindowInsets?.displayCutout?.run { safeInsetTop + safeInsetBottom } ?: 0
+            else -> 0
+        }
+
     private val navigationBarHeight by lazy {
-        val dimenId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
-        resources.getDimensionPixelSize(dimenId)
+        physicalScreenHeight - usableScreenHeight - cutoutsHeight
     }
 
     init {

--- a/alerter/src/main/java/com/tapadoo/alerter/Alert.kt
+++ b/alerter/src/main/java/com/tapadoo/alerter/Alert.kt
@@ -129,15 +129,15 @@ class Alert @JvmOverloads constructor(context: Context,
         }
     }
 
-    private val usableScreenHeight: Int
-        get() = Resources.getSystem().displayMetrics.heightPixels
-
     private val physicalScreenHeight: Int
         get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
             DisplayMetrics().also { currentDisplay?.getRealMetrics(it) }.heightPixels
         } else {
             usableScreenHeight
         }
+
+    private val usableScreenHeight: Int
+        get() = Resources.getSystem().displayMetrics.heightPixels
 
     private val cutoutsHeight: Int
         get() = when {


### PR DESCRIPTION
### What this PR does:
This PR fixes [Alert may has extra bottom margin when displayed with Gravity.BOTTOM](https://github.com/Tapadoo/Alerter/issues/267) issue.
Getting `navigationBarHeight` by subtracting (`usableScreenHeight`) and all possible cutouts (`cutoutsHeight`) from the physical screen height (`physicalScreenHeight`).

### Demos left to right:
- OnePlus 5 Android 10 w/o and w/ virtual navigation bar
- Xiaomi Mi A2 Android 11 w/ full and gesture navigation bars
- Pixel 3 XL Android 9 with top notch to test with extra cutouts
<div style="display:flex;" >
<img src="https://user-images.githubusercontent.com/7419173/127139859-ac1038a8-cb93-4e46-9261-037ad45bded1.gif" width="20%" >
<img src="https://user-images.githubusercontent.com/7419173/127139926-e543db25-bd51-441d-82a9-2c013b8f86b6.gif" width="20%" >
<img src="https://user-images.githubusercontent.com/7419173/127139932-d60da0cb-bdee-45ed-a742-b5c6732be636.gif" width="20%" >
</div>
